### PR TITLE
track the owner for Methodprototype and use a descriptor than using field directly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-version = '0.0.5'
+version = '0.0.6'
 
 def ENV = System.getenv()
 version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpression.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpression.java
@@ -123,7 +123,9 @@ public class LambdaExpression extends AbstractExpression implements LambdaExpres
             }
             if (multi) d.separator(")");
         }
-        d.print(" -> ").dump(result);
+        d.print(" -> ");
+        d.informBytecodeLoc(result);
+        d.dump(result);
         d.removePendingCarriageReturn();
         return d;
     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/AbstractFieldVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/AbstractFieldVariable.java
@@ -23,6 +23,7 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
     private final ClassFileField classFileField;
     private final String failureName; // if we can't get the classfileField.
     private final JavaTypeInstance owningClass;
+    private final String descriptor;
 
     AbstractFieldVariable(ConstantPoolEntry field) {
         super(getFieldType((ConstantPoolEntryFieldRef) field));
@@ -30,6 +31,7 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
         this.classFileField = getField(fieldRef);
         this.failureName = fieldRef.getLocalName();
         this.owningClass = fieldRef.getClassEntry().getTypeInstance();
+        this.descriptor = fieldRef.getNameAndTypeEntry().getDescriptor().getValue();
     }
 
     AbstractFieldVariable(ClassFileField field, JavaTypeInstance owningClass) {
@@ -37,6 +39,7 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
         this.classFileField = field;
         this.failureName = field.getFieldName();
         this.owningClass = owningClass;
+        this.descriptor = field.getField().getDescriptor();
     }
 
     AbstractFieldVariable(AbstractFieldVariable other) {
@@ -44,6 +47,7 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
         this.classFileField = other.classFileField;
         this.failureName = other.failureName;
         this.owningClass = other.owningClass;
+        this.descriptor = other.descriptor;
     }
 
     AbstractFieldVariable(InferredJavaType type, JavaTypeInstance clazz, String varName) {
@@ -51,6 +55,7 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
         this.classFileField = null;
         this.owningClass = clazz;
         this.failureName = varName;
+        this.descriptor = type.getJavaTypeInstance().getRawName(); // matching only
     }
 
     AbstractFieldVariable(InferredJavaType type, JavaTypeInstance clazz, ClassFileField classFileField) {
@@ -58,6 +63,7 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
         this.classFileField = classFileField;
         this.owningClass = clazz;
         this.failureName = null;
+        this.descriptor = classFileField.getField().getDescriptor();
     }
 
     @Override
@@ -128,6 +134,10 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
 
     public Field getField() {
         return classFileField == null ? null : classFileField.getField();
+    }
+
+    public String getDescriptor() {
+        return descriptor;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/FieldVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/FieldVariable.java
@@ -133,7 +133,7 @@ public class FieldVariable extends AbstractFieldVariable {
                 object.dumpWithOuterPrecedence(d, getPrecedence(), Troolean.NEITHER).separator(".");
             }
         }
-        return d.fieldName(getFieldName(), getField(), getOwningClassType(), isHiddenDeclaration(), false);
+        return d.fieldName(getFieldName(), getDescriptor(), getOwningClassType(), isHiddenDeclaration(), false,false);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/StaticVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/StaticVariable.java
@@ -69,9 +69,9 @@ public class StaticVariable extends AbstractFieldVariable {
     @Override
     public Dumper dumpInner(Dumper d) {
         if (knownSimple) {
-            return d.fieldName(getFieldName(), getField(), getOwningClassType(), false, false);
+            return d.fieldName(getFieldName(), getDescriptor(), getOwningClassType(), false, true, false);
         } else {
-            return d.dump(getOwningClassType(), TypeContext.Static).separator(".").fieldName(getFieldName(), getField(), getOwningClassType(), false, false);
+            return d.dump(getOwningClassType(), TypeContext.Static).separator(".").fieldName(getFieldName(), getDescriptor(), getOwningClassType(), false, true, false);
         }
     }
 

--- a/src/org/benf/cfr/reader/bytecode/analysis/structured/expression/StructuredStatementExpression.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/structured/expression/StructuredStatementExpression.java
@@ -25,13 +25,13 @@ public class StructuredStatementExpression extends AbstractExpression {
     private StructuredStatement content;
 
     public StructuredStatementExpression(InferredJavaType inferredJavaType, StructuredStatement content) {
-        super(BytecodeLoc.TODO, inferredJavaType);
+        super(content.getLoc(), inferredJavaType);
         this.content = content;
     }
 
     @Override
     public BytecodeLoc getCombinedLoc() {
-        return BytecodeLoc.TODO;
+        return getLoc();
     }
 
     /*

--- a/src/org/benf/cfr/reader/bytecode/analysis/structured/statement/StructuredCase.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/structured/statement/StructuredCase.java
@@ -82,7 +82,7 @@ public class StructuredCase extends AbstractStructuredBlockStatement {
                     // don't show the case part of that.
                     StaticVariable enumStatic = getEnumStatic(value);
                     if (enumStatic != null) {
-                        dumper.keyword("case ").fieldName(enumStatic.getFieldName(), enumStatic.getField(), enumStatic.getOwningClassType(), false, false).separator(": ");
+                        dumper.keyword("case ").fieldName(enumStatic.getFieldName(), enumStatic.getDescriptor(), enumStatic.getOwningClassType(), false, true, false).separator(": ");
                         if (x != last) dumper.newln();
                         continue;
                     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
@@ -82,6 +82,7 @@ public class MethodPrototype implements TypeUsageCollectable {
     private final List<Slot> syntheticArgs = ListFactory.newList();
     private final List<Slot> syntheticCaptureArgs = ListFactory.newList();
     private List<ParameterLValue> parameterLValues = null;
+    private final JavaTypeInstance owner; // fabric
 //    private static int sid = 0;
 //    private final int id = sid++;
 
@@ -143,6 +144,7 @@ public class MethodPrototype implements TypeUsageCollectable {
         this.name = name;
         this.fixedName = null;
         this.classFile = classFile;
+        this.owner = classType;
     }
 
     public OverloadMethodSet getOverloadMethodSet() {
@@ -453,6 +455,10 @@ public class MethodPrototype implements TypeUsageCollectable {
             types.add(type);
         }
         return types;
+    }
+
+    public JavaTypeInstance getOwner() {
+        return owner;
     }
 
     public JavaTypeInstance getClassType() {

--- a/src/org/benf/cfr/reader/entities/Field.java
+++ b/src/org/benf/cfr/reader/entities/Field.java
@@ -206,7 +206,7 @@ public class Field implements KnowsRawSize, TypeUsageCollectable {
             d.dump(comments);
             d.dump(jah);
         }
-        d.print(' ').fieldName(name, this, owner.getClassType(), false, true);
+        d.print(' ').fieldName(name, getDescriptor(), owner.getClassType(), false, false, true);
     }
 
     public boolean isAccessibleFrom(JavaRefTypeInstance maybeCaller, ClassFile classFile) {

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperEnum.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperEnum.java
@@ -51,7 +51,7 @@ public class ClassFileDumperEnum extends AbstractClassFileDumper {
     private static void dumpEntry(Dumper d, Pair<StaticVariable, AbstractConstructorInvokation> entry, boolean last, JavaTypeInstance classType) {
         StaticVariable staticVariable = entry.getFirst();
         AbstractConstructorInvokation constructorInvokation = entry.getSecond();
-        d.fieldName(staticVariable.getFieldName(), staticVariable.getField(), classType, false, true);
+        d.fieldName(staticVariable.getFieldName(), staticVariable.getDescriptor(), classType, false, true, true);
         d.dumpFieldDoc(staticVariable.getField(), classType);
 
         if (constructorInvokation instanceof ConstructorInvokationSimple) {

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperEnum.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperEnum.java
@@ -51,8 +51,8 @@ public class ClassFileDumperEnum extends AbstractClassFileDumper {
     private static void dumpEntry(Dumper d, Pair<StaticVariable, AbstractConstructorInvokation> entry, boolean last, JavaTypeInstance classType) {
         StaticVariable staticVariable = entry.getFirst();
         AbstractConstructorInvokation constructorInvokation = entry.getSecond();
-        d.fieldName(staticVariable.getFieldName(), staticVariable.getDescriptor(), classType, false, true, true);
         d.dumpFieldDoc(staticVariable.getField(), classType);
+        d.fieldName(staticVariable.getFieldName(), staticVariable.getDescriptor(), classType, false, true, true);
 
         if (constructorInvokation instanceof ConstructorInvokationSimple) {
             List<Expression> args = constructorInvokation.getArgs();

--- a/src/org/benf/cfr/reader/mapping/Mapping.java
+++ b/src/org/benf/cfr/reader/mapping/Mapping.java
@@ -216,17 +216,18 @@ public class Mapping implements ObfuscationMapping {
         }
 
         @Override
-        public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+        public Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
             JavaTypeInstance deGenerifiedType = owner.getDeGenerifiedType();
             ClassMapping c = erasedTypeMap.get(deGenerifiedType);
             if (c == null || hiddenDeclaration) {
-                delegate.fieldName(name, field, owner, hiddenDeclaration, defines);
+                delegate.fieldName(name, descriptor, owner, hiddenDeclaration, isStatic, defines);
             } else {
                 delegate.fieldName(
-                        c.getFieldName(name, deGenerifiedType,this, Mapping.this, field.testAccessFlag(AccessFlag.ACC_STATIC)),
-                        field,
+                        c.getFieldName(name, deGenerifiedType,this, Mapping.this, isStatic),
+                        descriptor,
                         owner,
                         hiddenDeclaration,
+                        isStatic,
                         defines);
             }
             return this;

--- a/src/org/benf/cfr/reader/state/TypeUsageCollectingDumper.java
+++ b/src/org/benf/cfr/reader/state/TypeUsageCollectingDumper.java
@@ -98,7 +98,7 @@ public class TypeUsageCollectingDumper implements Dumper {
     }
 
     @Override
-    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+    public Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
         return this;
     }
 

--- a/src/org/benf/cfr/reader/util/output/DelegatingDumper.java
+++ b/src/org/benf/cfr/reader/util/output/DelegatingDumper.java
@@ -83,8 +83,8 @@ public abstract class DelegatingDumper implements Dumper {
     }
 
     @Override
-    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
-        delegate.fieldName(name, field, owner, hiddenDeclaration, defines);
+    public Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
+        delegate.fieldName(name, descriptor, owner, hiddenDeclaration, isStatic, defines);
         return this;
     }
 

--- a/src/org/benf/cfr/reader/util/output/Dumper.java
+++ b/src/org/benf/cfr/reader/util/output/Dumper.java
@@ -47,7 +47,8 @@ public interface Dumper extends MethodErrorCollector {
 
     Dumper packageName(JavaRefTypeInstance t);
 
-    Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines);
+    // descriptor can be null for beautification (Math.PI) or dummy fields for equality checks
+    Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines);
 
     Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines);
 

--- a/src/org/benf/cfr/reader/util/output/StreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/StreamDumper.java
@@ -76,7 +76,7 @@ public abstract class StreamDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+    public Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
         identifier(name, null, defines);
         return this;
     }

--- a/src/org/benf/cfr/reader/util/output/ToStringDumper.java
+++ b/src/org/benf/cfr/reader/util/output/ToStringDumper.java
@@ -55,7 +55,7 @@ public class ToStringDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+    public Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
         return identifier(name, null, defines);
     }
 

--- a/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
@@ -267,7 +267,7 @@ public class TokenStreamDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+    public Dumper fieldName(String name, String descriptor, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
         if (defines) {
             sink(new Token(FIELD, name, SinkReturns.TokenTypeFlags.DEFINES));
         } else {


### PR DESCRIPTION
1. Methodprototype should expose its owner, as its class type isn't always available.
2. field are now dumped with descriptor than with field object; field object isn't always available, such as for some super class fields referenced in subclass, as seen in `LookControl`'s use of `Entity.headYaw` (compare procyon vs cfr)

These are all the cfr changes I propose up to now. I next plan to update enigma with `Entity.headYaw` fix (this bug also affects `Entity.world` calls), and have the enigma's bad entry references fixed altogether.

CC @modmuss50 