### PR TITLE
Don't try replace existing obf mapping in DCCommonState

### DIFF
--- a/src/org/benf/cfr/reader/Driver.java
+++ b/src/org/benf/cfr/reader/Driver.java
@@ -51,8 +51,10 @@ class Driver {
      */
     static void doClass(DCCommonState dcCommonState, String path, boolean skipInnerClass, DumperFactory dumperFactory) {
         Options options = dcCommonState.getOptions();
-        ObfuscationMapping mapping = MappingFactory.get(options, dcCommonState);
-        dcCommonState = new DCCommonState(dcCommonState, mapping);
+        if (dcCommonState.getObfuscationMapping() == null) {
+            ObfuscationMapping mapping = MappingFactory.get(options, dcCommonState);
+            dcCommonState = new DCCommonState(dcCommonState, mapping);
+        }
 
         IllegalIdentifierDump illegalIdentifierDump = IllegalIdentifierDump.Factory.get(options);
         Dumper d = new ToStringDumper(); // sentinel dumper.
@@ -114,8 +116,10 @@ class Driver {
     static void doJar(DCCommonState dcCommonState, String path, AnalysisType analysisType, DumperFactory dumperFactory) {
         Options options = dcCommonState.getOptions();
         IllegalIdentifierDump illegalIdentifierDump = IllegalIdentifierDump.Factory.get(options);
-        ObfuscationMapping mapping = MappingFactory.get(options, dcCommonState);
-        dcCommonState = new DCCommonState(dcCommonState, mapping);
+        if (dcCommonState.getObfuscationMapping() == null) {
+            ObfuscationMapping mapping = MappingFactory.get(options, dcCommonState);
+            dcCommonState = new DCCommonState(dcCommonState, mapping);
+        }
 
         SummaryDumper summaryDumper = null;
         try {


### PR DESCRIPTION
Makes it possible to pass through a DCCommonState with existing obf mappings.