### PR TITLE
Use correct class identifier for doubly-nested classes

### DIFF
--- a/src/org/benf/cfr/reader/util/output/TypeOverridingDumper.java
+++ b/src/org/benf/cfr/reader/util/output/TypeOverridingDumper.java
@@ -28,6 +28,11 @@ public class TypeOverridingDumper extends DelegatingDumper {
     }
 
     @Override
+    public Dumper dump(JavaTypeInstance javaTypeInstance, boolean defines) {
+        return dump(javaTypeInstance);
+    }
+
+    @Override
     public Dumper withTypeUsageInformation(TypeUsageInformation innerclassTypeUsageInformation) {
         return new TypeOverridingDumper(delegate, innerclassTypeUsageInformation);
     }


### PR DESCRIPTION
Close #14 

After a lot of trial and error, I believe the root cause is by this line: https://github.com/FabricMC/cfr/commit/88546ecf24da9a6de82e557ce2fd4df882159f43#diff-43bc0ec4fddd35ec74b31cc91c3bcf581729e2fc4a47415d9a799cf7f61f44bfR1201, which exists ever since we've forked from upstream.

I myself am not familiar with CFR internals. Maybe @Runemoro can check if my fix will affect anything critical.

I've only tested by decompiling Minecraft 1.18.2 and compare the output source, the result are pretty much identical except the incorrect syntax described in #14.

Here's the full diff:

```diff
diff --git a/com/mojang/blaze3d/systems/RenderSystem.java b/com/mojang/blaze3d/systems/RenderSystem.java
index 323429c..d4d1c9a 100644
--- a/com/mojang/blaze3d/systems/RenderSystem.java
+++ b/com/mojang/blaze3d/systems/RenderSystem.java
@@ -1249,7 +1249,7 @@ public class RenderSystem {
         }
 
         @Environment(value=EnvType.CLIENT)
-        static interface IndexBuffer.IndexMapper {
+        static interface IndexMapper {
             public void accept(IntConsumer var1, int var2);
         }
     }
diff --git a/net/minecraft/block/AbstractBlock.java b/net/minecraft/block/AbstractBlock.java
index 3b2bedb..76b4645 100644
--- a/net/minecraft/block/AbstractBlock.java
+++ b/net/minecraft/block/AbstractBlock.java
@@ -985,7 +985,7 @@ public abstract class AbstractBlock {
             return this.toolRequired;
         }
 
-        static final class AbstractBlockState.ShapeCache {
+        static final class ShapeCache {
             private static final Direction[] DIRECTIONS = Direction.values();
             private static final int SHAPE_TYPE_LENGTH = SideShapeType.values().length;
             protected final boolean fullOpaque;
diff --git a/net/minecraft/block/DoubleBlockProperties.java b/net/minecraft/block/DoubleBlockProperties.java
index 2e73989..dd8036f 100644
--- a/net/minecraft/block/DoubleBlockProperties.java
+++ b/net/minecraft/block/DoubleBlockProperties.java
@@ -49,7 +49,7 @@ public class DoubleBlockProperties {
     public static interface PropertySource<S> {
         public <T> T apply(PropertyRetriever<? super S, T> var1);
 
-        public static final class PropertySource.Single<S>
+        public static final class Single<S>
         implements PropertySource<S> {
             private final S single;
 
@@ -63,7 +63,7 @@ public class DoubleBlockProperties {
             }
         }
 
-        public static final class PropertySource.Pair<S>
+        public static final class Pair<S>
         implements PropertySource<S> {
             private final S first;
             private final S second;
diff --git a/net/minecraft/client/gui/screen/CustomizeBuffetLevelScreen.java b/net/minecraft/client/gui/screen/CustomizeBuffetLevelScreen.java
index 15a6d91..0befdd3 100644
--- a/net/minecraft/client/gui/screen/CustomizeBuffetLevelScreen.java
+++ b/net/minecraft/client/gui/screen/CustomizeBuffetLevelScreen.java
@@ -107,7 +107,7 @@ extends Screen {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class BuffetBiomesListWidget.BuffetBiomeItem
+        class BuffetBiomeItem
         extends AlwaysSelectedEntryListWidget.Entry<BuffetBiomeItem> {
             final RegistryEntry.Reference<Biome> biome;
             final Text text;
diff --git a/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.java b/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.java
index b5e7c44..f8f4191 100644
--- a/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.java
+++ b/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.java
@@ -166,7 +166,7 @@ extends Screen {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class SuperflatLayersListWidget.SuperflatLayerEntry
+        class SuperflatLayerEntry
         extends AlwaysSelectedEntryListWidget.Entry<SuperflatLayerEntry> {
             SuperflatLayerEntry() {
             }
diff --git a/net/minecraft/client/gui/screen/PresetsScreen.java b/net/minecraft/client/gui/screen/PresetsScreen.java
index 9c401d2..6771eaa 100644
--- a/net/minecraft/client/gui/screen/PresetsScreen.java
+++ b/net/minecraft/client/gui/screen/PresetsScreen.java
@@ -307,7 +307,7 @@ extends Screen {
         }
 
         @Environment(value=EnvType.CLIENT)
-        public class SuperflatPresetsListWidget.SuperflatPresetEntry
+        public class SuperflatPresetEntry
         extends AlwaysSelectedEntryListWidget.Entry<SuperflatPresetEntry> {
             private final SuperflatPreset preset;
 
diff --git a/net/minecraft/client/gui/screen/StatsScreen.java b/net/minecraft/client/gui/screen/StatsScreen.java
index 81a41bc..a7941b5 100644
--- a/net/minecraft/client/gui/screen/StatsScreen.java
+++ b/net/minecraft/client/gui/screen/StatsScreen.java
@@ -190,7 +190,7 @@ implements StatsListener {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class GeneralStatsListWidget.Entry
+        class Entry
         extends AlwaysSelectedEntryListWidget.Entry<Entry> {
             private final Stat<Identifier> stat;
             private final Text displayName;
@@ -390,7 +390,7 @@ implements StatsListener {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class ItemStatsListWidget.ItemComparator
+        class ItemComparator
         implements Comparator<Entry> {
             ItemComparator() {
             }
@@ -426,7 +426,7 @@ implements StatsListener {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class ItemStatsListWidget.Entry
+        class Entry
         extends AlwaysSelectedEntryListWidget.Entry<Entry> {
             private final Item item;
 
@@ -480,7 +480,7 @@ implements StatsListener {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class EntityStatsListWidget.Entry
+        class Entry
         extends AlwaysSelectedEntryListWidget.Entry<Entry> {
             private final Text entityTypeName;
             private final Text killedText;
diff --git a/net/minecraft/client/gui/screen/option/LanguageOptionsScreen.java b/net/minecraft/client/gui/screen/option/LanguageOptionsScreen.java
index 9319e94..9fe2645 100644
--- a/net/minecraft/client/gui/screen/option/LanguageOptionsScreen.java
+++ b/net/minecraft/client/gui/screen/option/LanguageOptionsScreen.java
@@ -100,7 +100,7 @@ extends GameOptionsScreen {
         }
 
         @Environment(value=EnvType.CLIENT)
-        public class LanguageSelectionListWidget.LanguageEntry
+        public class LanguageEntry
         extends AlwaysSelectedEntryListWidget.Entry<LanguageEntry> {
             final LanguageDefinition languageDefinition;
 
diff --git a/net/minecraft/client/gui/screen/recipebook/RecipeAlternativesWidget.java b/net/minecraft/client/gui/screen/recipebook/RecipeAlternativesWidget.java
index fd735af..d9c14b7 100644
--- a/net/minecraft/client/gui/screen/recipebook/RecipeAlternativesWidget.java
+++ b/net/minecraft/client/gui/screen/recipebook/RecipeAlternativesWidget.java
@@ -273,7 +273,7 @@ Element {
         }
 
         @Environment(value=EnvType.CLIENT)
-        protected class AlternativeButtonWidget.InputSlot {
+        protected class InputSlot {
             public final ItemStack[] stacks;
             public final int y;
             public final int x;
diff --git a/net/minecraft/client/realms/gui/screen/RealmsPendingInvitesScreen.java b/net/minecraft/client/realms/gui/screen/RealmsPendingInvitesScreen.java
index d3d3bcb..408601a 100644
--- a/net/minecraft/client/realms/gui/screen/RealmsPendingInvitesScreen.java
+++ b/net/minecraft/client/realms/gui/screen/RealmsPendingInvitesScreen.java
@@ -280,7 +280,7 @@ extends RealmsScreen {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class PendingInvitationSelectionListEntry.AcceptButton
+        class AcceptButton
         extends RealmsAcceptRejectButton {
             AcceptButton() {
                 super(15, 15, 215, 5);
@@ -304,7 +304,7 @@ extends RealmsScreen {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class PendingInvitationSelectionListEntry.RejectButton
+        class RejectButton
         extends RealmsAcceptRejectButton {
             RejectButton() {
                 super(15, 15, 235, 5);
diff --git a/net/minecraft/client/render/RenderLayer.java b/net/minecraft/client/render/RenderLayer.java
index 4bad06c..0f59e0c 100644
--- a/net/minecraft/client/render/RenderLayer.java
+++ b/net/minecraft/client/render/RenderLayer.java
@@ -448,7 +448,7 @@ extends RenderPhase {
         }
 
         @Environment(value=EnvType.CLIENT)
-        public static class MultiPhaseParameters.Builder {
+        public static class Builder {
             private RenderPhase.TextureBase texture = RenderPhase.NO_TEXTURE;
             private RenderPhase.Shader shader = RenderPhase.NO_SHADER;
             private RenderPhase.Transparency transparency = RenderPhase.NO_TRANSPARENCY;
diff --git a/net/minecraft/client/render/RenderPhase.java b/net/minecraft/client/render/RenderPhase.java
index 5dc21f4..730d390 100644
--- a/net/minecraft/client/render/RenderPhase.java
+++ b/net/minecraft/client/render/RenderPhase.java
@@ -521,7 +521,7 @@ public abstract class RenderPhase {
         }
 
         @Environment(value=EnvType.CLIENT)
-        public static final class Textures.Builder {
+        public static final class Builder {
             private final ImmutableList.Builder<Triple<Identifier, Boolean, Boolean>> textures = new ImmutableList.Builder();
 
             public Builder add(Identifier id, boolean blur, boolean mipmap) {
diff --git a/net/minecraft/client/render/VertexFormatElement.java b/net/minecraft/client/render/VertexFormatElement.java
index 25fc60a..afda6ec 100644
--- a/net/minecraft/client/render/VertexFormatElement.java
+++ b/net/minecraft/client/render/VertexFormatElement.java
@@ -150,13 +150,13 @@ public class VertexFormatElement {
 
         @FunctionalInterface
         @Environment(value=EnvType.CLIENT)
-        static interface Type.Starter {
+        static interface Starter {
             public void setupBufferState(int var1, int var2, int var3, long var4, int var6, int var7);
         }
 
         @FunctionalInterface
         @Environment(value=EnvType.CLIENT)
-        static interface Type.Finisher {
+        static interface Finisher {
             public void clearBufferState(int var1, int var2);
         }
     }
diff --git a/net/minecraft/client/render/chunk/ChunkBuilder.java b/net/minecraft/client/render/chunk/ChunkBuilder.java
index 3539fd3..557e9f5 100644
--- a/net/minecraft/client/render/chunk/ChunkBuilder.java
+++ b/net/minecraft/client/render/chunk/ChunkBuilder.java
@@ -436,7 +436,7 @@ public class ChunkBuilder {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class BuiltChunk.SortTask
+        class SortTask
         extends Task {
             private final ChunkData data;
 
@@ -496,7 +496,7 @@ public class ChunkBuilder {
         }
 
         @Environment(value=EnvType.CLIENT)
-        abstract class BuiltChunk.Task
+        abstract class Task
         implements Comparable<Task> {
             protected final double distance;
             protected final AtomicBoolean cancelled = new AtomicBoolean(false);
@@ -525,7 +525,7 @@ public class ChunkBuilder {
         }
 
         @Environment(value=EnvType.CLIENT)
-        class BuiltChunk.RebuildTask
+        class RebuildTask
         extends Task {
             @Nullable
             protected ChunkRendererRegion region;
diff --git a/net/minecraft/loot/context/LootContext.java b/net/minecraft/loot/context/LootContext.java
index 3c9c13e..dc892ad 100644
--- a/net/minecraft/loot/context/LootContext.java
+++ b/net/minecraft/loot/context/LootContext.java
@@ -150,7 +150,7 @@ public class LootContext {
             throw new IllegalArgumentException("Invalid entity target " + type);
         }
 
-        public static class EntityTarget.Serializer
+        public static class Serializer
         extends TypeAdapter<EntityTarget> {
             public void write(JsonWriter jsonWriter, EntityTarget entityTarget) throws IOException {
                 jsonWriter.value(entityTarget.type);
diff --git a/net/minecraft/recipe/CuttingRecipe.java b/net/minecraft/recipe/CuttingRecipe.java
index e384ccf..300a98e 100644
--- a/net/minecraft/recipe/CuttingRecipe.java
+++ b/net/minecraft/recipe/CuttingRecipe.java
@@ -124,7 +124,7 @@ implements Recipe<Inventory> {
             return this.read(id, json);
         }
 
-        static interface Serializer.RecipeFactory<T extends CuttingRecipe> {
+        static interface RecipeFactory<T extends CuttingRecipe> {
             public T create(Identifier var1, String var2, Ingredient var3, ItemStack var4);
         }
     }
diff --git a/net/minecraft/server/ServerMetadata.java b/net/minecraft/server/ServerMetadata.java
index fcf3804..a1e37d5 100644
--- a/net/minecraft/server/ServerMetadata.java
+++ b/net/minecraft/server/ServerMetadata.java
@@ -106,7 +106,7 @@ public class ServerMetadata {
             this.sample = sample;
         }
 
-        public static class Players.Deserializer
+        public static class Deserializer
         implements JsonDeserializer<Players>,
         JsonSerializer<Players> {
             public Players deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
@@ -171,7 +171,7 @@ public class ServerMetadata {
             return this.protocolVersion;
         }
 
-        public static class Version.Serializer
+        public static class Serializer
         implements JsonDeserializer<Version>,
         JsonSerializer<Version> {
             public Version deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
diff --git a/net/minecraft/server/ServerNetworkIo.java b/net/minecraft/server/ServerNetworkIo.java
index a5eaac0..42107e7 100644
--- a/net/minecraft/server/ServerNetworkIo.java
+++ b/net/minecraft/server/ServerNetworkIo.java
@@ -235,7 +235,7 @@ public class ServerNetworkIo {
             packet.context.fireChannelRead(packet.message);
         }
 
-        static class DelayingChannelInboundHandler.Packet {
+        static class Packet {
             public final ChannelHandlerContext context;
             public final Object message;
 
diff --git a/net/minecraft/util/dynamic/EntryLoader.java b/net/minecraft/util/dynamic/EntryLoader.java
index 5b5e862..87eef6e 100644
--- a/net/minecraft/util/dynamic/EntryLoader.java
+++ b/net/minecraft/util/dynamic/EntryLoader.java
@@ -136,7 +136,7 @@ public interface EntryLoader {
             return Optional.of(decoder.parse(json, (Object)element.data).setLifecycle(element.lifecycle).map(value -> Entry.of(value, element.id)));
         }
 
-        record Impl.Element(JsonElement data, int id, Lifecycle lifecycle) {
+        record Element(JsonElement data, int id, Lifecycle lifecycle) {
         }
     }
 
diff --git a/net/minecraft/world/biome/source/util/MultiNoiseUtil.java b/net/minecraft/world/biome/source/util/MultiNoiseUtil.java
index 2ed578b..f79c99c 100644
--- a/net/minecraft/world/biome/source/util/MultiNoiseUtil.java
+++ b/net/minecraft/world/biome/source/util/MultiNoiseUtil.java
@@ -202,7 +202,7 @@ public class MultiNoiseUtil {
             return new Result(new BlockPos(x, 0, z), l + m);
         }
 
-        record FittestPositionFinder.Result(BlockPos location, long fitness) {
+        record Result(BlockPos location, long fitness) {
         }
     }
 
@@ -370,7 +370,7 @@ public class MultiNoiseUtil {
             return treeLeafNode.value;
         }
 
-        static abstract class SearchTree.TreeNode<T> {
+        static abstract class TreeNode<T> {
             protected final ParameterRange[] parameters;
 
             protected TreeNode(List<ParameterRange> parameters) {
@@ -392,7 +392,7 @@ public class MultiNoiseUtil {
             }
         }
 
-        static final class SearchTree.TreeBranchNode<T>
+        static final class TreeBranchNode<T>
         extends TreeNode<T> {
             final TreeNode<T>[] subTree;
 
@@ -423,7 +423,7 @@ public class MultiNoiseUtil {
             }
         }
 
-        static final class SearchTree.TreeLeafNode<T>
+        static final class TreeLeafNode<T>
         extends TreeNode<T> {
             final T value;
 
diff --git a/net/minecraft/world/gen/densityfunction/DensityFunctionTypes.java b/net/minecraft/world/gen/densityfunction/DensityFunctionTypes.java
index 6eead04..dc7a5a7 100644
--- a/net/minecraft/world/gen/densityfunction/DensityFunctionTypes.java
+++ b/net/minecraft/world/gen/densityfunction/DensityFunctionTypes.java
@@ -1032,7 +1032,7 @@ public final class DensityFunctionTypes {
             }
         }
 
-        static interface TerrainShaperSpline.class_7053 {
+        static interface class_7053 {
             public float apply(VanillaTerrainParameters var1, VanillaTerrainParameters.NoisePoint var2);
         }
     }
diff --git a/net/minecraft/world/gen/surfacebuilder/MaterialRules.java b/net/minecraft/world/gen/surfacebuilder/MaterialRules.java
index e57dca6..d34c6c6 100644
--- a/net/minecraft/world/gen/surfacebuilder/MaterialRules.java
+++ b/net/minecraft/world/gen/surfacebuilder/MaterialRules.java
@@ -150,7 +150,7 @@ public class MaterialRules {
         @Override
         public BooleanSupplier apply(final MaterialRuleContext materialRuleContext) {
             final boolean bl = this.surfaceType == VerticalSurfaceType.CEILING;
-            class StoneDepthMaterialCondition.StoneDepthPredicate
+            class StoneDepthPredicate
             extends FullLazyAbstractPredicate {
                 StoneDepthPredicate() {
                     super(materialRuleContext2);
@@ -225,7 +225,7 @@ public class MaterialRules {
 
         @Override
         public BooleanSupplier apply(final MaterialRuleContext materialRuleContext) {
-            class AboveYMaterialCondition.AboveYPredicate
+            class AboveYPredicate
             extends FullLazyAbstractPredicate {
                 AboveYPredicate() {
                     super(materialRuleContext2);
@@ -256,7 +256,7 @@ public class MaterialRules {
 
         @Override
         public BooleanSupplier apply(final MaterialRuleContext materialRuleContext) {
-            class WaterMaterialCondition.WaterPredicate
+            class WaterPredicate
             extends FullLazyAbstractPredicate {
                 WaterPredicate() {
                     super(materialRuleContext2);
@@ -294,7 +294,7 @@ public class MaterialRules {
 
         @Override
         public BooleanSupplier apply(final MaterialRuleContext materialRuleContext) {
-            class BiomeMaterialCondition.BiomePredicate
+            class BiomePredicate
             extends FullLazyAbstractPredicate {
                 BiomePredicate() {
                     super(materialRuleContext2);
@@ -345,7 +345,7 @@ public class MaterialRules {
         @Override
         public BooleanSupplier apply(final MaterialRuleContext materialRuleContext) {
             final DoublePerlinNoiseSampler doublePerlinNoiseSampler = materialRuleContext.surfaceBuilder.getNoiseSampler(this.noise);
-            class NoiseThresholdMaterialCondition.NoiseThresholdPredicate
+            class NoiseThresholdPredicate
             extends HorizontalLazyAbstractPredicate {
                 NoiseThresholdPredicate() {
                     super(materialRuleContext2);
@@ -380,7 +380,7 @@ public class MaterialRules {
             final int i = this.trueAtAndBelow().getY(materialRuleContext.heightContext);
             final int j = this.falseAtAndAbove().getY(materialRuleContext.heightContext);
             final RandomDeriver randomDeriver = materialRuleContext.surfaceBuilder.getRandomDeriver(this.randomName());
-            class VerticalGradientMaterialCondition.VerticalGradientPredicate
+            class VerticalGradientPredicate
             extends FullLazyAbstractPredicate {
                 VerticalGradientPredicate() {
                     super(materialRuleContext2);
@@ -822,7 +822,7 @@ public class MaterialRules {
             return this.surfaceMinY;
         }
 
-        static class MaterialRuleContext.BiomeTemperaturePredicate
+        static class BiomeTemperaturePredicate
         extends FullLazyAbstractPredicate {
             BiomeTemperaturePredicate(MaterialRuleContext materialRuleContext) {
                 super(materialRuleContext);
@@ -834,7 +834,7 @@ public class MaterialRules {
             }
         }
 
-        static class MaterialRuleContext.SteepSlopePredicate
+        static class SteepSlopePredicate
         extends HorizontalLazyAbstractPredicate {
             SteepSlopePredicate(MaterialRuleContext materialRuleContext) {
                 super(materialRuleContext);
@@ -860,7 +860,7 @@ public class MaterialRules {
             }
         }
 
-        static final class MaterialRuleContext.NegativeRunDepthPredicate
+        static final class NegativeRunDepthPredicate
         extends HorizontalLazyAbstractPredicate {
             NegativeRunDepthPredicate(MaterialRuleContext materialRuleContext) {
                 super(materialRuleContext);
@@ -872,7 +872,7 @@ public class MaterialRules {
             }
         }
 
-        final class MaterialRuleContext.SurfacePredicate
+        final class SurfacePredicate
         implements BooleanSupplier {
             SurfacePredicate() {
             }
```

