### PR TITLE
use MethodParameter attribute if code attribute is missing

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableMethodParameter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableMethodParameter.java
@@ -1,0 +1,49 @@
+package org.benf.cfr.reader.bytecode.analysis.variables;
+
+import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.entities.attributes.MethodParameterEntry;
+import org.benf.cfr.reader.util.output.Dumper;
+
+import java.util.List;
+
+public class NamedVariableMethodParameter implements NamedVariable {
+    private String name;
+    private boolean forced = false;
+    private List<MethodParameterEntry> parameters;
+
+    public NamedVariableMethodParameter(List<MethodParameterEntry> parameters, String name) {
+        this.name = name;
+        this.parameters = parameters;
+    }
+
+    @Override
+    public void forceName(String name) {
+        this.name = name;
+        forced = true;
+    }
+
+    @Override
+    public String getStringName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean isGoodName() {
+        return true;
+    }
+
+    @Override
+    public Dumper dump(Dumper d) {
+        return dump(d, false);
+    }
+
+    @Override
+    public Dumper dump(Dumper d, boolean defines) {
+        return d.variableName(name, this, defines);
+    }
+
+    @Override
+    public Dumper dumpParameter(Dumper d, MethodPrototype prototype, int index, boolean defines) {
+        return d.parameterName(forced ? name : parameters.get(index).name.getValue(), this, prototype, index, defines);
+    }
+}

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableMethodParameter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableMethodParameter.java
@@ -2,6 +2,8 @@ package org.benf.cfr.reader.bytecode.analysis.variables;
 
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.entities.attributes.MethodParameterEntry;
+import org.benf.cfr.reader.entities.constantpool.ConstantPool;
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryUTF8;
 import org.benf.cfr.reader.util.output.Dumper;
 
 import java.util.List;
@@ -9,11 +11,13 @@ import java.util.List;
 public class NamedVariableMethodParameter implements NamedVariable {
     private String name;
     private boolean forced = false;
-    private List<MethodParameterEntry> parameters;
+    private final List<MethodParameterEntry> parameters;
+    private final ConstantPool cp;
 
-    public NamedVariableMethodParameter(List<MethodParameterEntry> parameters, String name) {
+    public NamedVariableMethodParameter(List<MethodParameterEntry> parameters, String name, ConstantPool cp) {
         this.name = name;
         this.parameters = parameters;
+        this.cp = cp;
     }
 
     @Override
@@ -44,6 +48,13 @@ public class NamedVariableMethodParameter implements NamedVariable {
 
     @Override
     public Dumper dumpParameter(Dumper d, MethodPrototype prototype, int index, boolean defines) {
-        return d.parameterName(forced ? name : parameters.get(index).name.getValue(), this, prototype, index, defines);
+        if (forced) {
+            return d.parameterName(name, this, prototype, index, defines);
+        }
+        int nameIndex = parameters.get(index).nameIndex;
+        if (nameIndex == 0) {
+            return d.parameterName(name, this, prototype, index, defines);
+        }
+        return d.parameterName(((ConstantPoolEntryUTF8)cp.getEntry(nameIndex)).getValue(), this, prototype, index, defines);
     }
 }

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/VariableNamerMethodParameter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/VariableNamerMethodParameter.java
@@ -1,0 +1,38 @@
+package org.benf.cfr.reader.bytecode.analysis.variables;
+
+import org.benf.cfr.reader.entities.attributes.LocalVariableEntry;
+import org.benf.cfr.reader.entities.attributes.MethodParameterEntry;
+import org.benf.cfr.reader.util.collections.MapFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class VariableNamerMethodParameter implements VariableNamer {
+    private final VariableNamer missingNamer = new VariableNamerDefault();
+    private final List<MethodParameterEntry> parameters;
+    private final Map<LocalVariableEntry, NamedVariable> cache = MapFactory.newMap();
+
+    public VariableNamerMethodParameter(List<MethodParameterEntry> parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public NamedVariable getName(int originalRawOffset, Ident ident, long stackPosition, boolean clashed) {
+        return new NamedVariableMethodParameter(parameters, null);
+    }
+
+    @Override
+    public List<NamedVariable> getNamedVariables() {
+        return missingNamer.getNamedVariables();
+    }
+
+    @Override
+    public void mutatingRenameUnClash(NamedVariable toRename) {
+        missingNamer.mutatingRenameUnClash(toRename);
+    }
+
+    @Override
+    public void forceName(Ident ident, long stackPosition, String name) {
+        missingNamer.forceName(ident, stackPosition, name);
+    }
+}

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/VariableNamerMethodParameter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/VariableNamerMethodParameter.java
@@ -2,6 +2,7 @@ package org.benf.cfr.reader.bytecode.analysis.variables;
 
 import org.benf.cfr.reader.entities.attributes.LocalVariableEntry;
 import org.benf.cfr.reader.entities.attributes.MethodParameterEntry;
+import org.benf.cfr.reader.entities.constantpool.ConstantPool;
 import org.benf.cfr.reader.util.collections.MapFactory;
 
 import java.util.List;
@@ -10,15 +11,16 @@ import java.util.Map;
 public class VariableNamerMethodParameter implements VariableNamer {
     private final VariableNamer missingNamer = new VariableNamerDefault();
     private final List<MethodParameterEntry> parameters;
-    private final Map<LocalVariableEntry, NamedVariable> cache = MapFactory.newMap();
+    private final ConstantPool cp;
 
-    public VariableNamerMethodParameter(List<MethodParameterEntry> parameters) {
+    public VariableNamerMethodParameter(List<MethodParameterEntry> parameters, ConstantPool cp) {
         this.parameters = parameters;
+        this.cp = cp;
     }
 
     @Override
     public NamedVariable getName(int originalRawOffset, Ident ident, long stackPosition, boolean clashed) {
-        return new NamedVariableMethodParameter(parameters, null);
+        return new NamedVariableMethodParameter(parameters, null, cp);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/Method.java
+++ b/src/org/benf/cfr/reader/entities/Method.java
@@ -148,7 +148,7 @@ public class Method implements KnowsRawSize, TypeUsageCollectable {
             // Because we don't have a code attribute, we don't have a local variable table.
             AttributeMethodParameters methodParameters = attributes.getByName(AttributeMethodParameters.ATTRIBUTE_NAME);
             if (methodParameters != null) {
-                this.variableNamer = new VariableNamerMethodParameter(methodParameters.getParameters());
+                this.variableNamer = new VariableNamerMethodParameter(methodParameters.getParameters(), cp);
             } else {
                 this.variableNamer = VariableNamerFactory.getNamer(null, cp);
             }

--- a/src/org/benf/cfr/reader/entities/Method.java
+++ b/src/org/benf/cfr/reader/entities/Method.java
@@ -7,6 +7,7 @@ import org.benf.cfr.reader.bytecode.analysis.variables.VariableNamer;
 import org.benf.cfr.reader.bytecode.analysis.variables.VariableNamerFactory;
 import org.benf.cfr.reader.bytecode.analysis.types.*;
 import org.benf.cfr.reader.bytecode.analysis.types.DeclarationAnnotationHelper.DeclarationAnnotationsInfo;
+import org.benf.cfr.reader.bytecode.analysis.variables.VariableNamerMethodParameter;
 import org.benf.cfr.reader.entities.annotations.AnnotationTableEntry;
 import org.benf.cfr.reader.entities.annotations.AnnotationTableTypeEntry;
 import org.benf.cfr.reader.entities.annotations.ElementValue;
@@ -145,7 +146,12 @@ public class Method implements KnowsRawSize, TypeUsageCollectable {
         AttributeCode codeAttribute = attributes.getByName(AttributeCode.ATTRIBUTE_NAME);
         if (codeAttribute == null) {
             // Because we don't have a code attribute, we don't have a local variable table.
-            this.variableNamer = VariableNamerFactory.getNamer(null, cp);
+            AttributeMethodParameters methodParameters = attributes.getByName(AttributeMethodParameters.ATTRIBUTE_NAME);
+            if (methodParameters != null) {
+                this.variableNamer = new VariableNamerMethodParameter(methodParameters.getParameters());
+            } else {
+                this.variableNamer = VariableNamerFactory.getNamer(null, cp);
+            }
             this.codeAttribute = null;
         } else {
             this.codeAttribute = codeAttribute;

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeMethodParameters.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeMethodParameters.java
@@ -26,7 +26,7 @@ public class AttributeMethodParameters extends Attribute {
         for (long i = 0; i < count; i++) {
             int nameIndex = raw.getU2At(offset);
             int accessFlags = raw.getU2At(offset + 2);
-            parameters.add(new MethodParameterEntry(cp.getEntry(nameIndex), accessFlags));
+            parameters.add(new MethodParameterEntry(nameIndex, accessFlags));
         }
     }
 

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeMethodParameters.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeMethodParameters.java
@@ -1,0 +1,55 @@
+package org.benf.cfr.reader.entities.attributes;
+
+import org.benf.cfr.reader.entities.constantpool.ConstantPool;
+import org.benf.cfr.reader.util.bytestream.ByteData;
+import org.benf.cfr.reader.util.collections.ListFactory;
+import org.benf.cfr.reader.util.output.Dumper;
+
+import java.util.List;
+
+public class AttributeMethodParameters extends Attribute {
+    public static final String ATTRIBUTE_NAME = "MethodParameters";
+
+    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
+    private static final long OFFSET_OF_REMAINDER = 6;
+    private static final long OFFSET_OF_PARAMETERS_COUNT = 6;
+    private static final long OFFSET_OF_PARAMETERS = 7;
+
+    private final int length;
+    private final int count;
+    private final List<MethodParameterEntry> parameters = ListFactory.newList();
+
+    public AttributeMethodParameters(ByteData raw, ConstantPool cp) {
+        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+        this.count = raw.getU1At(OFFSET_OF_PARAMETERS_COUNT);
+        long offset = OFFSET_OF_PARAMETERS;
+        for (long i = 0; i < count; i++) {
+            int nameIndex = raw.getU2At(offset);
+            int accessFlags = raw.getU2At(offset + 2);
+            parameters.add(new MethodParameterEntry(cp.getEntry(nameIndex), accessFlags));
+        }
+    }
+
+    public int getParameterCount() {
+        return count;
+    }
+
+    public List<MethodParameterEntry> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public Dumper dump(Dumper d) {
+        return d.print(ATTRIBUTE_NAME);
+    }
+
+    @Override
+    public String getRawName() {
+        return ATTRIBUTE_NAME;
+    }
+
+    @Override
+    public long getRawByteLength() {
+        return OFFSET_OF_REMAINDER + length;
+    }
+}

--- a/src/org/benf/cfr/reader/entities/attributes/MethodParameterEntry.java
+++ b/src/org/benf/cfr/reader/entities/attributes/MethodParameterEntry.java
@@ -1,14 +1,13 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntry;
 import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryUTF8;
 
 public class MethodParameterEntry {
-    public final ConstantPoolEntryUTF8 name;
+    public final int nameIndex;
     public final int accessFlags;
 
-    public MethodParameterEntry(ConstantPoolEntry name, int accessFlags) {
-        this.name = (ConstantPoolEntryUTF8) name;
+    public MethodParameterEntry(int nameIndex, int accessFlags) {
+        this.nameIndex = nameIndex;
         this.accessFlags = accessFlags;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/MethodParameterEntry.java
+++ b/src/org/benf/cfr/reader/entities/attributes/MethodParameterEntry.java
@@ -1,0 +1,14 @@
+package org.benf.cfr.reader.entities.attributes;
+
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntry;
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryUTF8;
+
+public class MethodParameterEntry {
+    public final ConstantPoolEntryUTF8 name;
+    public final int accessFlags;
+
+    public MethodParameterEntry(ConstantPoolEntry name, int accessFlags) {
+        this.name = (ConstantPoolEntryUTF8) name;
+        this.accessFlags = accessFlags;
+    }
+}

--- a/src/org/benf/cfr/reader/entityfactories/AttributeFactory.java
+++ b/src/org/benf/cfr/reader/entityfactories/AttributeFactory.java
@@ -81,6 +81,8 @@ public class AttributeFactory {
                 return new AttributeRecord(raw, cp, classFileVersion);
             } else if (AttributePermittedSubclasses.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributePermittedSubclasses(raw, cp);
+            } else if (AttributeMethodParameters.ATTRIBUTE_NAME.equals(attributeName)) {
+                return new AttributeMethodParameters(raw, cp);
             }
         } catch (Exception e) {
             // Can't handle it? Continue and process as an unknown attribute.


### PR DESCRIPTION
this applies parameter names for abstract methods and interface methods