### PR TITLE
Improve dumping of locals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-version = '0.2.1'
+version = '0.3.0-SNAPSHOT'
 
 def ENV = System.getenv()
 version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionFallback.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionFallback.java
@@ -141,11 +141,11 @@ public class LambdaExpressionFallback extends AbstractExpression implements Lamb
                 d.separator("(");
             }
             List<String> args = ListFactory.newList(n);
-            for (int x = 0; x < n; ++x) {
-                if (x > 0) d.separator(", ");
-                String arg = "arg_" + x;
+            for (int argPosition = 0; argPosition < n; ++argPosition) {
+                if (argPosition > 0) d.separator(", ");
+                String arg = "arg_" + argPosition;
                 args.add(arg);
-                d.parameterName(arg, arg, lambdaFn, x, true);
+                d.parameterName(arg, arg, lambdaFn, argPosition, lambdaFn.getParameterLValues().get(argPosition).localVariable.getIdx(), true);
             }
             if (multi) {
                 d.separator(")");

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/LambdaParameter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/LambdaParameter.java
@@ -6,17 +6,17 @@ import org.benf.cfr.reader.util.output.Dumper;
 
 public class LambdaParameter extends LocalVariable {
     public final MethodPrototype originalMethod;
-    public final int index; // index in method params, not slot
+    public final int argPosition; // index in method params, not slot
 
     public LambdaParameter(String name, InferredJavaType inferredJavaType, MethodPrototype originalMethod, int index) {
         super(name, inferredJavaType);
-        this.index = index;
+        this.argPosition = index;
         this.originalMethod = originalMethod;
     }
 
     @Override
     public Dumper dump(Dumper d, boolean defines) {
-        getName().dumpParameter(d, originalMethod, index, defines);
+        getName().dumpParameter(d, originalMethod, argPosition, originalMethod.getParameterLValues().get(argPosition).localVariable.getIdx(), defines);
         return d;
     }
 }

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/LocalVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/LocalVariable.java
@@ -111,12 +111,16 @@ public class LocalVariable extends AbstractLValue {
 
     @Override
     public Dumper dump(Dumper d, boolean defines) {
-        return name.dump(d, defines); // todo pass lv, lvt, start offset
+        if (ident != null && originalRawOffset != ident.getStackPos()) {
+            int i = 0;
+        }
+
+        return name.dumpLocalVariable(d, idx, -1, originalRawOffset, defines);
     }
 
     @Override
     public Dumper dumpInner(Dumper d) {
-        name.dump(d);
+        name.dumpLocalVariable(d, idx, -1, originalRawOffset, false);
         // Note that this print is only decorating when we have bad data.
         d.print(typeToString());
         return d;

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/utils/scope/LocalClassScopeDiscoverImpl.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/utils/scope/LocalClassScopeDiscoverImpl.java
@@ -75,7 +75,7 @@ public class LocalClassScopeDiscoverImpl extends AbstractLValueScopeDiscoverer {
         }
 
         @Override
-        public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines) {
+        public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int argPosition, int lvIndex, boolean defines) {
             return null;
         }
 

--- a/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
@@ -278,7 +278,7 @@ public class MethodPrototype implements TypeUsageCollectable {
                 annotationsHelper.dumpParamType(arg, paramIdx, d);
             }
             d.print(" ");
-            param.getName().dumpParameter(d, this, paramIdx, true);
+            param.getName().dumpParameter(d, this, paramIdx, getParameterLValues().get(paramIdx).localVariable.getIdx(), true);
         }
         d.separator(")");
     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/Ident.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/Ident.java
@@ -28,6 +28,10 @@ public class Ident {
         return true;
     }
 
+    public int getStackPos() {
+        return stackpos;
+    }
+
     public int getIdx() {
         return idx;
     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariable.java
@@ -17,12 +17,12 @@ public interface NamedVariable extends Dumpable {
     Dumper dump(Dumper d, boolean defines);
 
     // fabric start
-    default Dumper dumpParameter(Dumper d, MethodPrototype prototype, int index, boolean defines) {
+    default Dumper dumpParameter(Dumper d, MethodPrototype prototype, int argPosition, int lvIndex, boolean defines) {
         return dump(d, defines);
     }
 
     // start offset measured in instructions, not bytes
-    default Dumper dumpLocalVariable(Dumper d, int localVarIndex, Ident ident, int tableIndex, int startOffset, boolean defines) {
+    default Dumper dumpLocalVariable(Dumper d, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
         return dump(d, defines);
     }
 }

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableDefault.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableDefault.java
@@ -29,12 +29,17 @@ public class NamedVariableDefault implements NamedVariable {
 
     @Override
     public Dumper dump(Dumper d, boolean defines) {
-        return d.variableName(name, this, defines);
+        return d.variableName(name, -1, -1, -1, defines);
     }
 
     @Override
-    public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines) {
-        return d.parameterName(name, this, methodPrototype, index, defines);
+    public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int argPosition, int lvIndex, boolean defines) {
+        return d.parameterName(name, this, methodPrototype, argPosition, lvIndex, defines);
+    }
+
+    @Override
+    public Dumper dumpLocalVariable(Dumper d, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
+        return d.variableName(name, lvIndex, lvtRowIndex, startOpIndex, defines);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableFromHint.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableFromHint.java
@@ -31,12 +31,12 @@ public class NamedVariableFromHint implements NamedVariable {
 
     @Override
     public Dumper dump(Dumper d, boolean defines) {
-        return d.variableName(name, this, defines);
+        return d.variableName(name, slot, -1, -1, defines);
     }
 
     @Override
-    public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines) {
-        return d.parameterName(name, this, methodPrototype, index, defines);
+    public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int argPosition, int lvIndex, boolean defines) {
+        return d.parameterName(name, this, methodPrototype, argPosition, lvIndex, defines);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/VariableNamerHinted.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/VariableNamerHinted.java
@@ -64,6 +64,7 @@ public class VariableNamerHinted implements VariableNamer {
                 // if used in a legit location, however we should also track if this
                 // is an instance method.
                 if (name.equals(MiscConstants.THIS) && ident.getIdx() == 0) {
+                    namedVariable = new NamedVariableFromHint(name, 0, -1);
                     namedVariable.forceName(MiscConstants.THIS);
                 }
             } else {

--- a/src/org/benf/cfr/reader/state/TypeUsageCollectingDumper.java
+++ b/src/org/benf/cfr/reader/state/TypeUsageCollectingDumper.java
@@ -5,6 +5,7 @@ import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.bytecode.analysis.types.TypeConstants;
+import org.benf.cfr.reader.bytecode.analysis.variables.Ident;
 import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.entities.ClassFile;
 import org.benf.cfr.reader.entities.Field;
@@ -108,12 +109,12 @@ public class TypeUsageCollectingDumper implements Dumper {
     }
 
     @Override
-    public Dumper parameterName(String name, Object ref, MethodPrototype method, int index, boolean defines) {
+    public Dumper parameterName(String name, Object ref, MethodPrototype method, int argPosition, int lvIndex, boolean defines) {
         return this;
     }
 
     @Override
-    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
+    public Dumper variableName(String name, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
         return this;
     }
 

--- a/src/org/benf/cfr/reader/util/output/DelegatingDumper.java
+++ b/src/org/benf/cfr/reader/util/output/DelegatingDumper.java
@@ -4,6 +4,7 @@ import org.benf.cfr.reader.bytecode.analysis.loc.HasByteCodeLoc;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.Ident;
 import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
@@ -95,14 +96,14 @@ public abstract class DelegatingDumper implements Dumper {
     }
 
     @Override
-    public Dumper parameterName(String name, Object ref, MethodPrototype method, int index, boolean defines) {
-        delegate.parameterName(name, ref, method, index, defines);
+    public Dumper parameterName(String name, Object ref, MethodPrototype method, int argPosition, int lvIndex, boolean defines) {
+        delegate.parameterName(name, ref, method, argPosition, lvIndex, defines);
         return this;
     }
 
     @Override
-    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
-        delegate.variableName(name, variable, defines);
+    public Dumper variableName(String name, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
+        delegate.variableName(name, lvIndex, lvtRowIndex, startOpIndex, defines);
         return this;
     }
 

--- a/src/org/benf/cfr/reader/util/output/Dumper.java
+++ b/src/org/benf/cfr/reader/util/output/Dumper.java
@@ -4,6 +4,7 @@ import org.benf.cfr.reader.bytecode.analysis.loc.HasByteCodeLoc;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.Ident;
 import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
@@ -52,12 +53,10 @@ public interface Dumper extends MethodErrorCollector {
 
     Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines);
 
-    Dumper parameterName(String name, Object ref, MethodPrototype method, int index, boolean defines);
-
-    @Deprecated // todo add lv, lvt indices and start offset
-    Dumper variableName(String name, NamedVariable variable, boolean defines);
+    Dumper parameterName(String name, Object ref, MethodPrototype method, int argPosition, int lvIndex, boolean defines);
 
     // fabric
+    Dumper variableName(String name, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines);
     default Dumper dumpClassDoc(JavaTypeInstance owner) { return this; }
     default Dumper dumpMethodDoc(MethodPrototype method) { return this; }
     default Dumper dumpFieldDoc(Field field, JavaTypeInstance owner) { return this; }

--- a/src/org/benf/cfr/reader/util/output/StreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/StreamDumper.java
@@ -5,6 +5,7 @@ import org.benf.cfr.reader.bytecode.analysis.parse.utils.QuotingUtils;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.Ident;
 import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.mapping.NullMapping;
@@ -88,14 +89,14 @@ public abstract class StreamDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper parameterName(String name, Object ref, MethodPrototype method, int index, boolean defines) {
+    public Dumper parameterName(String name, Object ref, MethodPrototype method, int argPosition, int lvIndex, boolean defines) {
         identifier(name, ref, defines);
         return this;
     }
 
     @Override
-    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
-        identifier(name, variable, defines);
+    public Dumper variableName(String name, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
+        identifier(name, null, defines);
         return this;
     }
 

--- a/src/org/benf/cfr/reader/util/output/ToStringDumper.java
+++ b/src/org/benf/cfr/reader/util/output/ToStringDumper.java
@@ -3,6 +3,7 @@ package org.benf.cfr.reader.util.output;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.Ident;
 import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
@@ -64,13 +65,13 @@ public class ToStringDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper parameterName(String name, Object ref, MethodPrototype method, int index, boolean defines) {
+    public Dumper parameterName(String name, Object ref, MethodPrototype method, int argPosition, int lvIndex, boolean defines) {
         return identifier(name, ref, defines);
     }
 
     @Override
-    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
-        return identifier(name, variable, defines);
+    public Dumper variableName(String name, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
+        return identifier(name, null, defines);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
@@ -2,12 +2,9 @@ package org.benf.cfr.reader.util.output;
 
 import org.benf.cfr.reader.api.OutputSinkFactory;
 import org.benf.cfr.reader.api.SinkReturns;
-import org.benf.cfr.reader.bytecode.analysis.loc.HasByteCodeLoc;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
-import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
-import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
 import org.benf.cfr.reader.mapping.NullMapping;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
@@ -287,12 +284,12 @@ public class TokenStreamDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper parameterName(String name, Object ref, MethodPrototype method, int index, boolean defines) {
+    public Dumper parameterName(String name, Object ref, MethodPrototype method, int argPosition, int lvIndex, boolean defines) {
         return identifier(name, ref, defines);
     }
 
     @Override
-    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
+    public Dumper variableName(String name, int lvIndex, int lvtRowIndex, int startOpIndex, boolean defines) {
         return identifier(name, null, defines);
     }
 


### PR DESCRIPTION
This is my first time working with the CFR codebase, so I have no idea if what I changed could have any negative side effects. But from my testing in my [Enigma fork](https://github.com/WeaveMC/Enigma/tree/local-variable-support), the dumped information at least appears to be correct.